### PR TITLE
[ci] add release pipeline

### DIFF
--- a/.github/workflows/release-notes.md
+++ b/.github/workflows/release-notes.md
@@ -1,0 +1,1 @@
+Changelog [$TAG_VERSION](https://github.com/rosen-group/azure-devops_attachment-previewer_extension/blob/main/changelog.md#$TAG_VERSION)

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,63 @@
+# yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
+
+name: release
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag_version:
+        description: "Tag Version"
+        required: true
+  push:
+    tags:
+      - v[0-9]+.[0-9]+.[0-9]+
+
+jobs:
+
+  release:
+    name: release
+    runs-on: ubuntu-20.04
+
+    steps:
+
+    - name: Checkout Repository
+      uses: actions/checkout@v2
+
+    - name: Use Node.JS 16.x
+      uses: actions/setup-node@v3
+      with:
+        node-version: 16.x
+
+    - name: Set Tag Name for Workflow Dispatches
+      run: |
+        TAG_VERSION=${{ github.event.inputs.tag_version }}
+        echo "TAG_VERSION=$TAG_VERSION" >> $GITHUB_ENV
+      if: github.event_name == 'workflow_dispatch'
+
+    - name: Set Tag Name for Tag Pushes
+      run: |
+        TAG_VERSION=${{ github.ref }}
+        echo "TAG_VERSION=${TAG_VERSION#refs/tags/}" >> $GITHUB_ENV
+      if: github.event_name == 'push'
+
+    - name: Generate Changelog Notes
+      run: envsubst < $GITHUB_WORKSPACE/.github/workflows/release-notes.md > $RUNNER_TEMP/notes.md
+
+    - name: Install Dependencies
+      run: npm ci
+
+    - name: Set Package Version
+      run: |
+        VERSION=${TAG_VERSION#"v"}
+
+        sed --in-place 's/"0.0.0"/"'"$VERSION"'"/' package.json
+        sed --in-place 's/"0.0.0"/"'"$VERSION"'"/' azure-devops-extension.json
+
+    - name: Build Extension
+      run: npm run compile
+
+    - name: Package Extension
+      run: npm run package-extension
+
+    - name: Publish Release
+      run: gh release create $TAG_VERSION --title $TAG_VERSION --notes-file $RUNNER_TMP/notes.md --target $GITHUB_SHA *.vsix

--- a/azure-devops-extension.json
+++ b/azure-devops-extension.json
@@ -8,7 +8,7 @@
 
     "public": false,
 
-    "version": "1.0.39",
+    "version": "0.0.0",
 
     "publisher": "rosen-group",
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,0 +1,8 @@
+
+# Changelog
+
+## 1.0.0
+
+```diff
++ ADDED - Initial release of extension
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "rosen-group.azure-devops.attachment-previewer",
-  "version": "1.0.0",
+  "version": "0.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,22 @@
 {
   "name": "rosen-group.azure-devops.attachment-previewer",
-  "version": "1.0.0",
   "description": "",
+
+  "version": "0.0.0",
+
   "keywords": [
     "extensions",
     "Azure DevOps",
     "Visual Studio Team Services"
   ],
+
   "license": "MIT",
+
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/rosen-group/azure-devops_attachment-previewer_extension"
   },
+
   "scripts": {
     "clean": "rimraf ./dist",
     "compile": "npm run clean && npm run test && webpack --mode production",
@@ -23,6 +28,7 @@
     "publish-extension": "tfx extension publish --manifest-globs azure-devops-extension.json src/Modules/**/*.json",
     "test": "cross-env TEST_REPORT_FILENAME=test-results.xml jest --verbose"
   },
+
   "dependencies": {
     "azure-devops-extension-api": "1.157.0",
     "azure-devops-extension-sdk": "2.0.11",
@@ -30,6 +36,7 @@
     "react": "16.13.1",
     "react-dom": "16.13.1"
   },
+
   "devDependencies": {
     "@testing-library/jest-dom": "5.16.5",
     "@testing-library/react": "10.4.9",
@@ -52,6 +59,7 @@
     "webpack": "5.74.0",
     "webpack-cli": "4.10.0"
   },
+
   "jest": {
     "transform": {
       "^.+\\.(js|ts|tsx|jsx)$": "ts-jest"


### PR DESCRIPTION
## Summary

This pull-request adds a GitHub Action for releases, for all releases either
a tag can be created, or the workflow can be triggered manually with a
custom version, the corresponding tag will be created.