### PR TITLE
[ci] bump GitHub Actions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -8,15 +8,15 @@ jobs:
 
   test:
     name: test
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     steps:
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
     - name: Use Node.JS 16.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
         node-version: 16.x
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -16,7 +16,7 @@ jobs:
 
   release:
     name: release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     env:
       GH_REPO: ${{ github.repository }}
@@ -28,10 +28,10 @@ jobs:
     steps:
 
     - name: Checkout Repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
 
     - name: Use Node.JS 16.x
-      uses: actions/setup-node@v3
+      uses: actions/setup-node@64ed1c7eab4cce3362f8c340dee64e5eaeef8f7c # v3.6.0
       with:
         node-version: 16.x
 


### PR DESCRIPTION
This updates the runner images to the latest Ubuntu, being `22.04` and pins the versions for used actions.