### PR TITLE
[preview] fix typo in attachment selection prompt

### DIFF
--- a/src/Modules/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.tsx
+++ b/src/Modules/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.tsx
@@ -198,7 +198,7 @@ export class TestResultDetailsTabPreviewerComponent extends React.Component<{}, 
                                 primaryText="No attachment selected"
                                 secondaryText={
                                     <span>
-                                        Please selected a attachment to preview.
+                                        Please select an attachment to preview.
                                   </span>
                                 }
                                 imagePath=""


### PR DESCRIPTION
Instead of `Please selected a attachment to preview.` it should be `Please select an attachment to preview.`.