### PR TITLE
[preview] show attachments of overview test run

### DIFF
--- a/src/Tests/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.test.tsx
+++ b/src/Tests/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.test.tsx
@@ -8,7 +8,7 @@ import React from "react";
 import TestResultDetailsTabPreviewerComponent from "../../Modules/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer";
 
 import { mockGetProject, mockGetSubResultID, mockGetRunID, mockGetResultID } from "../../__mocks__/azure-devops-extension-sdk";
-import { mockGetTestSubResultAttachments, mockGetTestSubResultAttachmentContent, mockGetTestResultById } from "../../__mocks__/azure-devops-extension-api/TestResults";
+import { mockGetTestSubResultAttachments, mockGetTestSubResultAttachmentContent, mockGetTestResultById, mockGetTestRunAttachments } from "../../__mocks__/azure-devops-extension-api/TestResults";
 
 // related mocks for Azure DevOps are loaded automatically (implementations /src/__mocks__)
 
@@ -55,13 +55,14 @@ describe("TestResultDetailsTabPreviewerComponent", () => {
         expect(screen.getByText(/no attachments/i)).toBeDefined();
     });
 
-    test("should show no available attachments for invalid run", async () => {
+    test("should show no available attachments for run", async () => {
         // Arrange
         mockGetRunID.mockReturnValue(1);
         mockGetResultID.mockReturnValue(null);
         mockGetSubResultID.mockReturnValue(0);
 
         mockGetProject.mockResolvedValue({ name: "project" });
+        mockGetTestRunAttachments.mockResolvedValue([]);
 
         // Act
         render(<TestResultDetailsTabPreviewerComponent />);
@@ -70,6 +71,30 @@ describe("TestResultDetailsTabPreviewerComponent", () => {
 
         // Assert
         expect(screen.getByText(/no attachments/i)).toBeDefined();
+    });
+
+    test("should list attachments for run", async () => {
+        // Arrange
+        mockGetRunID.mockReturnValue(1);
+        mockGetResultID.mockReturnValue(null);
+        mockGetSubResultID.mockReturnValue(0);
+
+        mockGetProject.mockResolvedValue({ name: "project" });
+        mockGetTestRunAttachments.mockResolvedValue([
+            {
+                id: "attachment2",
+                fileName: "filename2",
+            }
+        ]);
+
+        // Act
+        render(<TestResultDetailsTabPreviewerComponent />);
+
+        await new Promise((resolve => setTimeout(resolve, 0)));
+
+        // Assert
+        expect(mockGetTestRunAttachments).toHaveBeenCalledWith(expect.any(String), expect.any(Number));
+        expect(screen.getByText(/filename2/i)).toBeDefined();
     });
 
     test("should show list attachments of last sub result", async () => {

--- a/src/__mocks__/azure-devops-extension-api/TestResults.ts
+++ b/src/__mocks__/azure-devops-extension-api/TestResults.ts
@@ -6,6 +6,7 @@ export const mockGetTestResultRestClientOptions = jest.fn(); // REST client opti
 
 export const mockGetTestResultById = jest.fn().mockResolvedValue({}); // test result
 
+export const mockGetTestRunAttachments = jest.fn().mockResolvedValue([]); // test attachments for test run with results
 export const mockGetTestSubResultAttachments = jest.fn().mockResolvedValue([]); // test result attachments for sub tests with results
 export const mockGetTestSubResultAttachmentContent = jest.fn().mockResolvedValue(new TextEncoder().encode("")); // test result attachment content for tests with sub results
 
@@ -20,6 +21,10 @@ export class TestResultsRestClient {
 
    public getTestResultById(project: string, run: any, result: any, details: any) {
       return mockGetTestResultById();
+   }
+
+   public getTestRunAttachments(project: string, run: any) {
+      return mockGetTestRunAttachments(project, run);
    }
 
    public getTestSubResultAttachments(project: string, run: any, result: any, sub: any) {


### PR DESCRIPTION
Previously only attachments were listed that are either of a run directly or the parent if multiple attempts exists. Now it also displays them for overview runs, these can contain general attachments that can be attached by things such as collectors.

<img width="1475" alt="image" src="https://github.com/rosen-group/azure-devops_attachment-previewer_extension/assets/26856437/20daea36-bb0f-4dcd-ae9c-1304cec58fe1">
