### PR TITLE
[package] downgrade Azure DevOps Extension API package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0",
       "license": "MIT",
       "dependencies": {
-        "azure-devops-extension-api": "2.218.0",
+        "azure-devops-extension-api": "1.157.0",
         "azure-devops-extension-sdk": "3.1.2",
         "azure-devops-ui": "2.167.64",
         "react": "16.13.1",
@@ -2206,9 +2206,9 @@
       "dev": true
     },
     "node_modules/azure-devops-extension-api": {
-      "version": "2.218.0",
-      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-2.218.0.tgz",
-      "integrity": "sha512-EpCXg2gamoa7cLu18oLZ2IWsPhqWHs0zFCkEdpLIZisTAbTRmxJzAIK2ktOjdDWiaYX/Q0wm9H2QNEr+HgIgoQ==",
+      "version": "1.157.0",
+      "resolved": "https://registry.npmjs.org/azure-devops-extension-api/-/azure-devops-extension-api-1.157.0.tgz",
+      "integrity": "sha512-CCN39A2VaRdi7MCeFWqhcv6dXOfSAf7W2jv1QWX1Hd9ac3n5PzguEPy+66SiPz5M+nDyMSP6aDTtwjEUX9D1kg==",
       "dependencies": {
         "azure-devops-extension-sdk": "~2.0.11",
         "whatwg-fetch": "~3.0.0"

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
 
   "dependencies": {
-    "azure-devops-extension-api": "2.218.0",
+    "azure-devops-extension-api": "1.157.0",
     "azure-devops-extension-sdk": "3.1.2",
     "azure-devops-ui": "2.167.64",
     "react": "16.13.1",


### PR DESCRIPTION
Starting with the initial v2 version there is a breaking change that makes use of the API version v7.2, this breaks compatibility with Azure DevOps Server.