### PR TITLE
[preview] treat JSON as plain text

### DIFF
--- a/src/Modules/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.tsx
+++ b/src/Modules/TestResultDetailsTabPreviewer/TestResultDetailsTabPreviewer.tsx
@@ -111,7 +111,6 @@ export class TestResultDetailsTabPreviewerComponent extends React.Component<{}, 
         "ico": "image/vnd.microsoft.icon",
         "jpeg": "image/jpeg",
         "jpg": "image/jpeg",
-        "json": "application/json",
         "png": "image/png",
         "svg": "image/svg+xml",
     };


### PR DESCRIPTION
This is to prevent the text theme issue when rendering the plain text via an iFrame.